### PR TITLE
Add Post Entity and In-Memory Datasource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,8 @@ typings/
 # next.js build output
 .next
 
+# Loopback
 dist8
+*.datasource.json
+
+data/

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "parser": "typescript",
   "printWidth": 120,
   "semi": false,
-  "singleQuote": true
+  "singleQuote": true,
+  "semicolons": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "crownlab",
+  "name": "crown-lab-api",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/application.ts
+++ b/src/application.ts
@@ -1,37 +1,51 @@
-import { ApplicationConfig } from '@loopback/core';
-import { RestApplication, RestServer, RestBindings } from '@loopback/rest';
-import { MySequence } from './sequence';
+import { ApplicationConfig } from '@loopback/core'
+import { RestApplication, RestServer, RestBindings } from '@loopback/rest'
+import { MySequence } from './sequence'
+import { DbDataSource } from './datasources/db.datasource'
 
 /* tslint:disable:no-unused-variable */
 // Binding and Booter imports are required to infer types for BootMixin!
-import { BootMixin, Booter, Binding } from '@loopback/boot';
+import { BootMixin, Booter, Binding } from '@loopback/boot'
+
+// juggler imports are required to infer types for RepositoryMixin!
+import { Class, Repository, RepositoryMixin, juggler } from '@loopback/repository'
 /* tslint:enable:no-unused-variable */
 
-export class CrownLabApplication extends BootMixin(RestApplication) {
+export class CrownLabApplication extends BootMixin(RepositoryMixin(RestApplication)) {
   constructor(options?: ApplicationConfig) {
-    super(options);
+    super(options)
 
     // Set up the custom sequence
-    this.sequence(MySequence);
+    this.sequence(MySequence)
 
-    this.projectRoot = __dirname;
+    this.projectRoot = __dirname
     // Customize @loopback/boot Booter Conventions here
     this.bootOptions = {
       controllers: {
         // Customize ControllerBooter Conventions here
         dirs: ['controllers'],
         extensions: ['.controller.js'],
-        nested: true,
-      },
-    };
+        nested: true
+      }
+    }
+
+    this.setupDatasources()
+  }
+
+  setupDatasources() {
+    // This will allow you to test your application without needing to
+    // use a "real" datasource!
+    const datasource =
+      this.options && this.options.datasource ? new juggler.DataSource(this.options.datasource) : DbDataSource
+    this.dataSource(datasource)
   }
 
   async start() {
-    await super.start();
+    await super.start()
 
-    const server = await this.getServer(RestServer);
-    const port = await server.get(RestBindings.PORT);
-    console.log(`Server is running at http://127.0.0.1:${port}`);
-    console.log(`Try http://127.0.0.1:${port}/ping`);
+    const server = await this.getServer(RestServer)
+    const port = await server.get(RestBindings.PORT)
+    console.log(`Server is running at http://127.0.0.1:${port}`)
+    console.log(`Try http://127.0.0.1:${port}/ping`)
   }
 }

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,1 +1,2 @@
 export * from './ping.controller';
+export * from './post.controller';

--- a/src/controllers/post.controller.ts
+++ b/src/controllers/post.controller.ts
@@ -1,0 +1,21 @@
+import { repository } from '@loopback/repository'
+import { PostRepository } from '../repositories'
+import { Post } from '../models'
+import { HttpErrors, post, param, requestBody, get, put, patch, del } from '@loopback/rest'
+
+export class PostController {
+  constructor(@repository(PostRepository) protected postRepo: PostRepository) {}
+
+  @post('/posts')
+  async createPost(@requestBody() post: Post) {
+    if (!post.title) {
+      throw new HttpErrors.BadRequest('title is required')
+    }
+    return await this.postRepo.create(post)
+  }
+
+  @get('/posts/{id}')
+  async findPostById(@param.path.number('id') id: number): Promise<Post> {
+    return await this.postRepo.findById(id)
+  }
+}

--- a/src/datasources/db.datasource.ts
+++ b/src/datasources/db.datasource.ts
@@ -1,0 +1,14 @@
+import { inject } from '@loopback/core'
+import { juggler, DataSource, AnyObject } from '@loopback/repository'
+const config = require('./db.datasource.json')
+
+export class DbDataSource extends juggler.DataSource {
+  static dataSourceName = 'db'
+
+  constructor(
+    @inject('datasources.config.db', { optional: true })
+    dsConfig: AnyObject = config
+  ) {
+    super(dsConfig)
+  }
+}

--- a/src/datasources/index.ts
+++ b/src/datasources/index.ts
@@ -1,0 +1,1 @@
+export * from './db.datasource';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,1 @@
+export * from './post.model'

--- a/src/models/post.model.ts
+++ b/src/models/post.model.ts
@@ -1,0 +1,26 @@
+import { Entity, property, model } from '@loopback/repository'
+
+@model()
+export class Post extends Entity {
+  @property({
+    type: 'number',
+    id: true
+  })
+  id?: number
+
+  @property({
+    type: 'string',
+    required: true
+  })
+  title: string
+
+  @property({
+    type: 'string',
+    required: true
+  })
+  body: string
+
+  getId() {
+    return this.id
+  }
+}

--- a/src/repositories/index.ts
+++ b/src/repositories/index.ts
@@ -1,0 +1,1 @@
+export * from './post.repository'

--- a/src/repositories/post.repository.ts
+++ b/src/repositories/post.repository.ts
@@ -1,0 +1,9 @@
+import { DefaultCrudRepository, juggler } from '@loopback/repository'
+import { Post } from '../models'
+import { inject } from '@loopback/core'
+
+export class PostRepository extends DefaultCrudRepository<Post, typeof Post.prototype.id> {
+  constructor(@inject('datasources.db') protected datasource: juggler.DataSource) {
+    super(Post, datasource)
+  }
+}


### PR DESCRIPTION
This creates a simple blog post entity with only a title and body fields.  This will hopefully
demonstrate how the loopback framework works in a basic fashion.  This creates a model
(which defines the a model's properties), a controller (which routes incoming requests to
the appropriate method), and a repository (which provides basic CRUD methods to the
in-memory datasource).  

The in-memory datasource is configured to persist all data into a json file in the ./data
directory.  Be sure to create a data dir andgive it the proper permissions.

You'll also need a `src/datasources/db.datasource.json` that basically hold each datasource's (this one is named "db") connection info (host, user, password, schema, etc.).  The file for an in-memory datasource is pretty simple.  

```{json}
{
  "name": "db",
  "connector": "memory",
  "localStorage": "no",
  "file": "./data/db.json"
}
```

PS: Sorry about all the formatting lines with semicolons removed.  I didn't realized I had added `"semicolons": false` to `.prettierrc`